### PR TITLE
Added possibility of setting PLATFORM manually.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,17 @@ PLATFORM = DEFAULT
 CC = gcc
 endif
 
+ifdef MYPLATFORM
+PLATFORM=$(MYPLATFORM)
+$(info Platform set to $(MYPLATFORM))
+endif
+
+ifeq ($(PLATFORM), DEFAULT)
+$(info PLATFORM set to DEFAULT. If you want to change it, pass MYPLATFORM=<platform>)
+$(info Possible platforms: OPTERON, XEON2, COREi7, XEON, NIAGARA, TILERA, T44)
+$(info ---------------------------)
+endif
+
 ifeq ($(PLATFORM_NUMA),1) #give PLATFORM_NUMA=1 for NUMA
 CFLAGS += -DNUMA
 LDFLAGS += -lnuma


### PR DESCRIPTION
Hey,

I just cloned the repo and fired `make` which ended up with:

```
$ make
gcc -D_GNU_SOURCE -DDEFAULT -c src/ssmem.c -O3 -Wall -I./include
Archive name = libssmem.a
ar -r libssmem.a ssmem.o 
rm -f *.o   
gcc -D_GNU_SOURCE -DDEFAULT -c src/ssmem_test.c -O3 -Wall -I./include
In file included from src/ssmem_test.c:57:0:
./include/utils.h: In function ‘get_cluster’:
./include/utils.h:296:22: error: ‘CORES_PER_SOCKET’ undeclared (first use in this function)
     return thread_id/CORES_PER_SOCKET;
                      ^
./include/utils.h:296:22: note: each undeclared identifier is reported only once for each function it appears in
src/ssmem_test.c: In function ‘test’:
src/ssmem_test.c:190:11: error: ‘the_cores’ undeclared (first use in this function)
   set_cpu(the_cores[ID]);
           ^
src/ssmem_test.c: In function ‘main’:
src/ssmem_test.c:289:11: error: ‘the_cores’ undeclared (first use in this function)
   set_cpu(the_cores[0]);
           ^
Makefile:96: recipe for target 'ssmem_test.o' failed
make: *** [ssmem_test.o] Error 1
```

After looking at `utils.h` file I realized, that my platform (COREi7) hasn't been properly detected - instead `DEFAULT` platform was loaded, but there are no defines for it in `utils.h`.

So I've added code to change platform manually.

In the end you should probably detect the platform somehow else, e.g. by parsing `lscpu | grep "Model name"` output.
